### PR TITLE
Fix dropbox

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DBX_TOKEN=dropbox-api-token-goes-here

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ package-lock.json
 node_modules
 *.css
 *.css.map
+.env

--- a/README.md
+++ b/README.md
@@ -6,18 +6,17 @@ Welcome to OfficeBeatZ (formerly known as the EmployeeWellnessProject), a simple
 
 OfficeBeatZ will help improve your health by reminding you to get up and move through the power of your favorite songs. Unlike boring or annoying alarm reminders, OfficeBeatz, we hope, will facilitate a fun, energizing environment in your workplace, all while improving your health!
 
-### Wiki & General Use (under construction)
-
-~~For general information regarding this project, please consult the [Wiki](https://github.com/CodyMichaelSimmons/EmployeeWellnessProject/wiki). The wiki contains much of the information regarding general use of the app and basic instructions.~~
+* [Beta/Staging](http://officebeatz2-beta.herokuapp.com/) - auto deploys from master
+* [Production](http://officebeatz2.herokuapp.com/) - manually promoted from beta
 
 ### Basic Setup
 
 To get your local files setup to make your own changes:
 
-1. Change to an empty directory and run `git clone https://github.com/officebeatz/OfficeBeatz2.git`
+1. `cd` to an empty directory and run `git clone https://github.com/officebeatz/OfficeBeatz2.git`.
 1. After the files are cloned, run `npm install` in the new directory to download dependencies.
-1. To run the app locally, you will need to have the Dropbox token set as a local variable on your computer.
-1. Once your token has been setup, using the command `npm start` will start the process on port 3752. You can access the app at http://localhost:3752/
+1. Rename the `.env.example` file to `.env` and edit the placeholder text with the Dropbox API token.
+1. Once your token has been setup, using the command `npm run dev-start` will start the process on port 3752. You can access the app at http://localhost:3752/
 
 ### Running Tests
 
@@ -55,9 +54,3 @@ However, your changes are still only in your branch that you made; if you want y
 1. Add any context/description/notes about your changes, and then you're good to go! Generally, try to list the changes you made, and add any comments you think might help others review your code.
 1. **Ask someone to review your code.** -- Changing master (including pull requests) is a protected branch, so it requires at least one reviewer to *approve* your pull request.
 1. Click **Merge**! -- Once your code has been reviewed (and nothing breaks when you run it on your local), then click merge! If there are merge conflicts, then feel free to ask Jason (the tech lead) to merge it for you.
-
-### Deploying
-
-To deploy `master` after changes have been made, go to the app on Heroku and click the `Deploy` option. It will ask which branch you want to deploy: select `master`. If any errors occur, Heroku will abort the process and give you an error message.
-
-~~Production can be found [here](http://officebeatz.net/). And beta / staging can be found [here](http://beta.officebeatz.net/).~~

--- a/app.js
+++ b/app.js
@@ -5,6 +5,12 @@ var cookieParser = require('cookie-parser');
 var logger = require('morgan');
 var sassMiddleware = require('node-sass-middleware');
 
+// load dev environment variables (BEFORE setting routes)
+if (process.env.NODE_ENV == 'dev') {
+    console.log("Loading dev .env variables");
+    require('dotenv').config();
+}
+
 var indexRouter = require('./routes/index');
 var usersRouter = require('./routes/users');
 
@@ -39,7 +45,7 @@ app.use('/users', usersRouter);
 
 /**
  * Passes 404 errors to the error handler.
- * @param {NextFunction} next 
+ * @param {NextFunction} next
  */
 app.use(function (req, res, next) {
   next(createError(404));

--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
+    "dev-start": "NODE_ENV=dev npm start",
     "start": "node ./bin/www",
     "test": "jasmine"
   },
   "dependencies": {
     "cookie-parser": "~1.4.3",
     "debug": "~2.6.9",
+    "dotenv": "^8.2.0",
     "dropbox": "^4.0.12",
     "express": "^4.16.4",
     "http-errors": "~1.6.2",


### PR DESCRIPTION
Changes:
- Added `npm run dev-start` as new command to start app locally
- Added instructions in README for setting up local .env files (ie Dropbox token)

Notes: 
- Everyone pulling master should rerun `npm install` to install a new dependency (node module `dotenv`) required to make this work.
- I also added the dropbox token to the config of the Heroku apps (and manually deployed them from master) so they are now live at officebeatz2-beta.herokuapp.com (auto-deploys from master) and officebeatz2.herokuapp.com (manually promoted from beta).