### PR TITLE
Add google analytics to all pages

### DIFF
--- a/views/layout.pug
+++ b/views/layout.pug
@@ -21,5 +21,14 @@ html
     meta(name='msapplication-TileImage', content="/images/mstile-144x144.png")
     meta(name='msapplication-config', content="/images/browserconfig.xml")
     meta(name='theme-color', content="#212121")
+
+    // Global site tag (gtag.js) - Google Analytics
+    script(async, src='https://www.googletagmanager.com/gtag/js?id=UA-161445530-1')
+    script.
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-161445530-1');
+
   body
     block content


### PR DESCRIPTION
The change injects 2 script tags - the base Google Analytics package, and some config code  - into the header of every page (in our case just the main page). 
> <img width="587" alt="Screen Shot 2020-03-19 at 7 22 06 PM" src="https://user-images.githubusercontent.com/18102685/77123732-5d47cc80-6a17-11ea-9a52-46fa4b293e24.png">
> 
> _screenshot from view-source:localhost:3752_

The script, upon loading on a user's browser, then connects with the Google Analytics account registered with employeewellnessmusicproject@gmail.com:
> <img width="349" alt="Screen Shot 2020-03-19 at 7 22 51 PM" src="https://user-images.githubusercontent.com/18102685/77123861-b0218400-6a17-11ea-8161-d1098c6ff606.png">
> 
> _screenshot from Google Analytics while I'm viewing the site running locally on my computer_
