### PR TITLE
Make corner logo icon clickable

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -8,6 +8,10 @@ $(document).ready(function () {
     // Initializes Materialize components.
     $('.tabs').tabs();
     $('.collapsible').collapsible();
+    // Make the corner logo also work as the 'Home' tab
+    $('#clickable-home').click(function() {
+        $('.tabs').tabs('select', 'home');
+    });
 
     let timeLeft = localStorage.getItem("TIME_INTERVAL") || 900000; // Defaults to 15 minutes if not previously set.
     let activeInterval = false;

--- a/views/components/new-header.pug
+++ b/views/components/new-header.pug
@@ -1,7 +1,7 @@
 header
   nav(class='nav-extended nav-color nav-center')
     div(class='nav-content')
-      div(class="logo", href='#home')
+      div(class="logo", id="clickable-home")
         img(src="images/favicon.ico")
       ul(class='tabs tabs-transparent')
         li(class='tab')


### PR DESCRIPTION
Clicking the corner logo icon now switches the tab to home (if it's not already), just like the home tab. Closes #49 