### PR TITLE
Cleanup song display

### DIFF
--- a/public/stylesheets/style.sass
+++ b/public/stylesheets/style.sass
@@ -160,7 +160,7 @@ nav.nav-center
 #current-song-display
   display: flex
   margin: auto
-  
+  padding-bottom: 5px
 
 .title-container a
   padding: 0 3px
@@ -311,11 +311,8 @@ input[type=number]::-webkit-inner-spin-button
 
 .title-container
   background-color: #212121
-  
-  line-height: 32px
 
-.100-wid
-  width: 100%
+  line-height: 32px
 
 .songDisplay
   color: #616161

--- a/views/components/song-controls.pug
+++ b/views/components/song-controls.pug
@@ -1,7 +1,6 @@
 //- need to mess with this class name to display & no slider
-div(class="100-wid")
-    div(class='title-container active', id="current-song-display")
-        a(class='songDisplay') Current song: 
-        a(id='titleID', class='songDisplay')
-        a(class='songDisplay')  by 
-        a(id='artistID', class='songDisplay')
+div(class='title-container active', id="current-song-display")
+    span(class='songDisplay', style="padding-right: 6px") Current song:
+    span(id='titleID')
+    span(class='songDisplay', style="padding: 0px 6px 0px 6px") by
+    span(id='artistID')


### PR DESCRIPTION
> BEFORE
<img width="794" alt="Screen Shot 2020-04-26 at 2 49 01 AM" src="https://user-images.githubusercontent.com/18102685/80300304-6db33b80-8769-11ea-8f20-751848d726db.png">

> AFTER
<img width="776" alt="Screen Shot 2020-04-26 at 2 41 56 AM" src="https://user-images.githubusercontent.com/18102685/80300306-7277ef80-8769-11ea-8eb6-67a8388bcfa8.png">

_DETAILS_
* added small padding to bottom of song display
* removed unnecessary html
* removed unnecessary CSS (see below)
> (Unnecessary/obfuscated CSS)
<img width="276" alt="Screen Shot 2020-04-26 at 2 47 06 AM" src="https://user-images.githubusercontent.com/18102685/80300282-4197ba80-8769-11ea-8ff1-21c6920469f0.png">

> Thanks to the `transition`, "Current song" was just barely highlighted for no reason 
<img width="715" alt="Screen Shot 2020-04-26 at 2 46 34 AM" src="https://user-images.githubusercontent.com/18102685/80300291-5411f400-8769-11ea-8f56-58b174eb31f4.png">

Closes #70

