### PR TITLE
fix country genre checkbox typo

### DIFF
--- a/views/components/form-holder/genre-form.pug
+++ b/views/components/form-holder/genre-form.pug
@@ -73,7 +73,7 @@ li(class="not-active")
         span )
     div
       label(for="countryBox")
-        input(name="genreGroup", type="checkbox", id="countyBox", class="genreGroup")
+        input(name="genreGroup", type="checkbox", id="countryBox", class="genreGroup")
         span Country
         span(class="starter") (
         span(id="genreCount") 12


### PR DESCRIPTION
Country checkbox wasn't clickable because I misspelled the id as `countyBox`. Fixed that