### PR TITLE
Update procfile to match new server file

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node app.js
+web: node start.js


### PR DESCRIPTION
#101 caused Heroku to crash because `Procfile` was not updated to match. Fixed.